### PR TITLE
Pointed dependences to repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "",
   "main": "client.js",
   "dependencies": {
-    "rasbus": "file:../rasbus"
+    "rasbus": "johntalton/rasbus"
   },
   "devDependencies": {
     "csv-writer": "^1.0.0",
-    "repler": "file:../repler"
+    "repler": "johntalton/repler"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Modified to point the dependencies to @johntalton repos on GitHub instead of local directories. Allows for a clean `npm install` with just a clone of this repo.